### PR TITLE
handle entitlement-created action to send tenant registration event

### DIFF
--- a/saas-reciever/constants.js
+++ b/saas-reciever/constants.js
@@ -1,11 +1,12 @@
 module.exports.MESSAGE_ACTION = {
   ENTITLEMENT_UPDATED: "entitlement-updated",
+  ENTITLEMENT_CREATED: "entitlement-created",
   SUBSCRIBE_SUCCESS: "subscribe-success",
-  UNSUBSCRIBE_SUCCESS: "unsubscribe-success"
-}
+  UNSUBSCRIBE_SUCCESS: "unsubscribe-success",
+};
 
 module.exports.ENV_VARS = {
   region: process.env.region || "us-east-1",
   LOG_LEVEL: process.env.LOG_LEVEL || "debug",
   EventBusName: process.env.eventBusName || null,
-}
+};

--- a/saas-reciever/index.js
+++ b/saas-reciever/index.js
@@ -1,64 +1,105 @@
 "use strict";
 const AWS = require("aws-sdk");
 const { MESSAGE_ACTION, ENV_VARS } = require("./constants");
-AWS.config.update({ region: ENV_VARS.region })
+const { PLAN_MAPPING } = require("./plan-mapping");
+AWS.config.update({ region: ENV_VARS.region });
 
 const eventBridge = new AWS.EventBridge();
 
 exports.handler = async (event) => {
-  event.Records.map(record => {
+  for (const record of event.Records) {
+    console.log("record: ", record);
     try {
       let { body } = record;
-      console.log("body", body);
+      console.log("body: ", body);
       body = JSON.parse(body);
+
       const [action, message] = body.Message.split("# ");
       const userDetails = JSON.parse(message);
-      console.log(userDetails);
-      userDetails.entitlement = typeof userDetails.entitlement == "string" ? JSON.parse(userDetails.entitlement) : userDetails.entitlement;
+      console.log("userDetails: ", userDetails);
+
+      userDetails.entitlement =
+        typeof userDetails.entitlement == "string"
+          ? JSON.parse(userDetails.entitlement)
+          : userDetails.entitlement;
+
       switch (action.toLowerCase()) {
         case MESSAGE_ACTION.ENTITLEMENT_UPDATED.toLowerCase():
-          const newPlan = userDetails.entitlement.Entitlements[0]["Dimension"];
-          console.log("Customer Choose new plan:-", newPlan.split("_")[0]);
+          break;
+        case MESSAGE_ACTION.ENTITLEMENT_CREATED.toLowerCase():
+          const selectedPlan =
+            userDetails.entitlement.Entitlements[0]["Dimension"];
+          const marketplacePlanKey = selectedPlan.split("_")[0];
+          console.log("Choosen plan:-", marketplacePlanKey);
+          const controlPlanePlanIdentifier = PLAN_MAPPING[marketplacePlanKey];
+
+          if (!controlPlanePlanIdentifier) {
+            console.error(
+              "Corresponding Plan not found in the mapping object."
+            );
+            break;
+          }
           const tenantRegistrationData = {
-            "customer": {
-              "firstName": userDetails.firstName,
-              "lastName": userDetails.lastName,
-              "email": userDetails.email,
-              "address": userDetails.address,
-              "zip": userDetails.zipcode,
-              "country": userDetails.country
+            company: {
+              name: userDetails.companyName,
             },
-            "appConfig": {
-              "preferredSubdomain": userDetails.preferredSubdomain
+            customer: {
+              firstName: userDetails.firstName,
+              lastName: userDetails.lastName,
+              email: userDetails.email,
+              address: userDetails.address,
+              zip: userDetails.zipcode,
+              country: userDetails.country,
             },
-            "plan": {
-              "identifier": newPlan
-            }
+            appConfig: {
+              preferredSubdomain: userDetails.preferredSubdomain,
+            },
+            plan: {
+              identifier: controlPlanePlanIdentifier,
+            },
           };
+          console.log("tenantRegistrationData", tenantRegistrationData);
           // Event parameters
-          const params = {
+          const tenantRegistrationEventParams = {
             Entries: [
               {
-                Source: 'com.saas.marketplace',
-                DetailType: 'TENANT_REGISTRATION',
+                Source: "com.saas.marketplace",
+                DetailType: "TENANT_REGISTRATION",
                 EventBusName: ENV_VARS.EventBusName,
                 Time: new Date(),
-                Detail: JSON.stringify(tenantRegistrationData)
-              }
-            ]
+                Detail: JSON.stringify(tenantRegistrationData),
+              },
+            ],
           };
-          console.log(params);
-          break;
-        case MESSAGE_ACTION.SUBSCRIBE_SUCCESS.toLowerCase():
+          console.log(
+            "tenantRegistrationEventParams",
+            tenantRegistrationEventParams
+          );
+          // send event to event bridge
+          const registrationEvent = await eventBridge
+            .putEvents({
+              Entries: tenantRegistrationEventParams.Entries,
+            })
+            .promise()
+            .catch((err) => {
+              console.log(
+                "Error in sending registration event to event bridge",
+                err
+              );
+            });
+
+          console.log("registrationEvent sent", registrationEvent);
           break;
         case MESSAGE_ACTION.UNSUBSCRIBE_SUCCESS.toLowerCase():
           break;
       }
     } catch (e) {
-      console.log(e.message);
+      console.log(
+        "Something went wrong while processing the record:",
+        e.message
+      );
     }
-  });
-  return {}
-}
+  }
+};
 
 // exports.handler(require("./events/sqs_event.json"));

--- a/saas-reciever/plan-mapping.js
+++ b/saas-reciever/plan-mapping.js
@@ -1,0 +1,5 @@
+// This object maps the plan keys in the AWS Marketplace to the corresponding plan names in the ARC SaaS Control plane
+module.exports.PLAN_MAPPING = {
+  standard: "Standard",
+  premium: "Premium",
+};


### PR DESCRIPTION
Added the snippet to send the TENANT_REGISTRATION event the the ARC SaaS Event Bus on event bridge.

This also introduces the Plan Mapping object intended to have the mapping of marketplace dimension keys to the plan names on ARC SaaS side. This identifier can be anything id, plan name or anything else. but currently for simplicity it's kept to be the Plan Name on the control plane side.